### PR TITLE
Left align build heading

### DIFF
--- a/styles/package-support/build.less
+++ b/styles/package-support/build.less
@@ -43,7 +43,7 @@ Atom Packages
     font-size: @font-size;
 
     .heading-text {
-      text-align: center;
+      text-align: left;
       font-weight: bold;
     }
   }


### PR DESCRIPTION

![bouncing](https://user-images.githubusercontent.com/933880/32978785-59da1530-cc49-11e7-8baf-4d93613d9902.gif)
Since the build timer takes variable width, the centered heading is moving left and right ever so slightly.