### PR TITLE
Use default styling on button for status-bar

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -22,4 +22,15 @@ status-bar {
   span {
     font-size: 11px;
   }
+
+  button {
+    border: none !important;
+    color: inherit !important;
+  }
+
+  button:hover {
+    border: none !important;
+    background-color: inherit !important;
+    color: inherit !important;
+  }
 }


### PR DESCRIPTION
Since Atom 1.31, the Github package has been using, for accessibility purpose, a button for the file count on the status-bar.

Before :
![screen shot 2018-10-05 at 12 03 55 pm](https://user-images.githubusercontent.com/5131277/46507813-e3f60180-c896-11e8-958c-fec635fa89af.png)
on hover
![screen shot 2018-10-05 at 12 04 14 pm](https://user-images.githubusercontent.com/5131277/46507818-e9534c00-c896-11e8-8c80-323e51c4cf85.png)


After :
![screen shot 2018-10-05 at 12 04 26 pm](https://user-images.githubusercontent.com/5131277/46507824-ec4e3c80-c896-11e8-8236-4a09a3d4cfd3.png)
on hover
![screen shot 2018-10-05 at 12 04 39 pm](https://user-images.githubusercontent.com/5131277/46507823-ec4e3c80-c896-11e8-8812-7955e0753d9f.png)


Two notes here :
- This happens because we are using !important on buttons, the quick solution being to reapply important again to override the default button styling.
- I decided to override this on status-bar directly to avoid the case where Atom or the Github package were to migrate every current links as buttons